### PR TITLE
lost libc fix

### DIFF
--- a/ext/fiddle/lib/fiddle/jruby.rb
+++ b/ext/fiddle/lib/fiddle/jruby.rb
@@ -164,6 +164,14 @@ module Fiddle
       end
     end
 
+    module LibC
+      extend FFI::Library
+      ffi_lib FFI::Library::LIBC
+      MALLOC = attach_function :malloc, [ :size_t ], :pointer
+      REALLOC = attach_function :realloc, [ :pointer, :size_t ], :pointer
+      FREE = attach_function :free, [ :pointer ], :void
+    end
+
     def self.malloc(size, free = nil)
       self.new(LibC.malloc(size), size, free ? free : LibC::FREE)
     end


### PR DESCRIPTION
removed in https://github.com/jruby/jruby/commit/7b964fdd9c07e2af3d94d300bd676cde847d621a#diff-9db60b68eedf0d5f16826d2ce0afb1c1

fixes https://github.com/jruby/jruby/issues/3462 (again)